### PR TITLE
Fix default address handling and node server port

### DIFF
--- a/fashion_payment/index.js
+++ b/fashion_payment/index.js
@@ -12,6 +12,9 @@ dotenv.config();
 const stripe = Stripe(process.env.STRIPE_SECRET);
 const endpointSecret = process.env.ENDPOINT_SECRET;
 
+// Default to port 3000 if no environment variable is provided
+const port = process.env.PORT || 3000;
+
 fireBaseConnection();
 
 app.post(
@@ -96,8 +99,8 @@ app.use(bodyParser.urlencoded({ limit: "10mb", extended: true }));
 
 app.use("/stripe", stripeRouter);
 
-app.listen(process.env.PORT || port, () =>
-  console.log(`App listening on port ${process.env.PORT}!`)
+app.listen(port, () =>
+  console.log(`App listening on port ${port}!`)
 );
 
 const createOrder = async (payload, accessToken, fcm) => {

--- a/pybackend/fashion_backend/extras/views.py
+++ b/pybackend/fashion_backend/extras/views.py
@@ -25,8 +25,14 @@ class AddAddress(APIView):
             addressType=data["addressType"],
         )
 
-        if user_address.isDefault == True:
-            models.Address.objects.filter(userId=request.user).update(isDefault=False)
+        if user_address.isDefault:
+            # Unset the default flag from all other addresses of the user
+            (
+                models.Address.objects
+                .filter(userId=request.user)
+                .exclude(id=user_address.id)
+                .update(isDefault=False)
+            )
 
         user_address.save()
 


### PR DESCRIPTION
## Summary
- ensure default address isn't overwritten when adding new addresses
- set default port constant and use it when starting the payment server

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68430a820a30833092157dcff708d598